### PR TITLE
Simplify dotenv usage

### DIFF
--- a/app/openai_client.py
+++ b/app/openai_client.py
@@ -1,11 +1,12 @@
 import json
 import logging
 import os
+from dotenv import load_dotenv
 import openai
 from .schemas import RecommendationResponse
-from config.settings import settings
 
-openai.api_key = settings.openai_api_key
+load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY")
 
 FUNCTION_SCHEMA = {
     "name": "recommend_actions",

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,10 +1,4 @@
-# BaseSettings moved to `pydantic_settings` in pydantic v2
-from pydantic_settings import BaseSettings
+from dotenv import load_dotenv
 
-class Settings(BaseSettings):
-    openai_api_key: str
-
-    class Config:
-        env_file = '.env'
-
-settings = Settings()
+# Load environment variables from a .env file if present
+load_dotenv()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ numpy==2.2.5
 python-dotenv==1.1.0
 fastapi==0.115.13
 uvicorn[standard]==0.34.3
-pydantic-settings>=2.9


### PR DESCRIPTION
## Summary
- drop `Settings` class
- call `load_dotenv` and `os.getenv` directly when configuring OpenAI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685452112920832a8844a1ec58c94220