### PR TITLE
feat: implement pipeline functionality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # Copy this file to .env and set your keys
 OPENAI_API_KEY=
+GOOGLE_ADS_CUSTOMER_ID=
+GOOGLE_PLAY_PACKAGE_NAME=

--- a/README.md
+++ b/README.md
@@ -27,11 +27,15 @@ python scripts/init_google_auth.py
 
 4. Copy `.env.example` to `.env` and set your `OPENAI_API_KEY`.
 
-5. Run the pipeline locally:
+5. Set the `GOOGLE_ADS_CUSTOMER_ID` and `GOOGLE_PLAY_PACKAGE_NAME`
+   environment variables to point to your Ads account and Play app.
+
+6. Run the pipeline locally:
 ```bash
 python -m app.main
 ```
-This fetches data and prints generated recommendations.
+This fetches data and writes generated recommendations to
+`recommendations.json`.
 
 You can also build and run the Docker image:
 ```bash

--- a/app/main.py
+++ b/app/main.py
@@ -2,28 +2,90 @@
 
 from __future__ import annotations
 
+import json
+import os
+from pathlib import Path
+from typing import Any
+
 import pandas as pd
+from google.ads.googleads.client import GoogleAdsClient
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
 
 from .openai_client import get_recommendations
 
 
+TOKEN_FILE = Path.home() / ".config/gads-play-optimizer/credentials.json"
+ADS_CONFIG_FILE = Path("config/google-ads.yaml")
+
+
 def export_ads() -> pd.DataFrame:
-    return pd.DataFrame()
+    """Export basic campaign metrics from Google Ads.
+
+    Returns a ``DataFrame`` with ``campaign_id``, ``impressions`` and ``clicks``
+    for the last seven days. The Google Ads customer ID must be provided via the
+    ``GOOGLE_ADS_CUSTOMER_ID`` environment variable.
+    """
+
+    customer_id = os.environ["GOOGLE_ADS_CUSTOMER_ID"]
+    client = GoogleAdsClient.load_from_storage(str(ADS_CONFIG_FILE))
+    ga_service = client.get_service("GoogleAdsService")
+    query = (
+        "SELECT campaign.id, metrics.impressions, metrics.clicks "
+        "FROM campaign WHERE segments.date DURING LAST_7_DAYS"
+    )
+    response = ga_service.search(customer_id=customer_id, query=query)
+    rows: list[dict[str, Any]] = []
+    for row in response:
+        rows.append(
+            {
+                "campaign_id": row.campaign.id,
+                "impressions": row.metrics.impressions,
+                "clicks": row.metrics.clicks,
+            }
+        )
+    return pd.DataFrame(rows)
 
 
 def export_play() -> pd.DataFrame:
-    return pd.DataFrame()
+    """Export basic review information from Google Play.
+
+    The Google Play package name must be supplied via the
+    ``GOOGLE_PLAY_PACKAGE_NAME`` environment variable. Only a subset of fields is
+    returned to keep the payload small.
+    """
+
+    package_name = os.environ["GOOGLE_PLAY_PACKAGE_NAME"]
+    creds = Credentials.from_authorized_user_file(str(TOKEN_FILE))
+    service = build("androidpublisher", "v3", credentials=creds)
+    result = service.reviews().list(packageName=package_name).execute()
+    rows: list[dict[str, Any]] = []
+    for review in result.get("reviews", []):
+        rating = review["comments"][0]["userComment"].get("starRating")
+        rows.append({"review_id": review["reviewId"], "rating": rating})
+    return pd.DataFrame(rows)
 
 
 def build_compact_json(df_ads: pd.DataFrame, df_play: pd.DataFrame) -> dict:
-    return {}
+    """Convert exported data frames into a compact JSON payload."""
+
+    return {
+        "google_ads": df_ads.to_dict(orient="records"),
+        "google_play": df_play.to_dict(orient="records"),
+    }
 
 
-def store_results(reco: dict) -> None:
-    print(reco)
+def store_results(reco: dict, path: Path | None = None) -> None:
+    """Store generated recommendations on disk."""
+
+    dest = path or Path("recommendations.json")
+    dest.write_text(json.dumps(reco, indent=2))
+    print(f"Saved recommendations to {dest}")
 
 
 def pipeline() -> None:
+    """Run the data export and recommendation pipeline."""
+
     df_ads = export_ads()
     df_play = export_play()
     compact = build_compact_json(df_ads, df_play)
@@ -32,6 +94,8 @@ def pipeline() -> None:
 
 
 def main() -> None:
+    """Entry point for ``python -m app.main``."""
+
     pipeline()
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,54 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from app import main
+from app.schemas import RecommendationResponse
+
+
+def test_build_compact_json():
+    df_ads = pd.DataFrame([{"campaign_id": 1, "impressions": 10}])
+    df_play = pd.DataFrame([{"review_id": "a", "rating": 5}])
+    result = main.build_compact_json(df_ads, df_play)
+    assert result == {
+        "google_ads": [{"campaign_id": 1, "impressions": 10}],
+        "google_play": [{"review_id": "a", "rating": 5}],
+    }
+
+
+def test_store_results(tmp_path: Path):
+    path = tmp_path / "out.json"
+    main.store_results({"foo": "bar"}, path=path)
+    assert json.loads(path.read_text()) == {"foo": "bar"}
+
+
+def test_pipeline(monkeypatch):
+    def fake_ads():
+        return pd.DataFrame([{"a": 1}])
+
+    def fake_play():
+        return pd.DataFrame([{"b": 2}])
+
+    called = {}
+
+    def fake_get_reco(_payload: dict):
+        called["payload"] = _payload
+        return RecommendationResponse(google_ads=["x"], google_play=["y"])
+
+    def fake_store(reco: dict, path=None):
+        called["result"] = reco
+        called["path"] = path
+
+    monkeypatch.setattr(main, "export_ads", fake_ads)
+    monkeypatch.setattr(main, "export_play", fake_play)
+    monkeypatch.setattr(main, "get_recommendations", fake_get_reco)
+    monkeypatch.setattr(main, "store_results", fake_store)
+
+    main.pipeline()
+
+    assert called["payload"] == {
+        "google_ads": [{"a": 1}],
+        "google_play": [{"b": 2}],
+    }
+    assert called["result"] == {"google_ads": ["x"], "google_play": ["y"]}


### PR DESCRIPTION
## Summary
- flesh out `app.main` to call Google Ads and Google Play APIs
- save recommendations to a JSON file
- add environment variables to `.env.example`
- mention new variables and output file in the README
- test pipeline helper functions

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68545b46ae00832aab4262d3fc07c89f